### PR TITLE
Update RunPod deployment Dockerfile for CUDA 12.4 runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,10 +225,11 @@ lives in [`serverless/runpod_worker.py`](serverless/runpod_worker.py) and the co
 ### Build and publish the container
 
 
-The `deploy/runpod/Dockerfile` image is based on `runpod/pytorch:0.7.0-cu1241-torch240-ubuntu2004`,
-which already includes CUDA-enabled `torch`, `torchvision`, and `torchaudio`. The accompanying
-`requirements-runpod.txt` intentionally omits those packages so the GPU builds provided by
-RunPod stay intact.
+The `deploy/runpod/Dockerfile` image is based on
+`nvidia/cuda:12.4.1-cudnn9-runtime-ubuntu22.04`. During the build we install Python 3 along with
+CUDA-enabled `torch==2.4.0`, `torchvision==0.19.0`, and `torchaudio==2.4.0` from the official
+PyTorch wheel index. The accompanying `requirements-runpod.txt` pins those packages and enables the
+`hf_transfer` extra in `huggingface-hub` so downloads work reliably on RunPod.
 
 #### Option A: Build locally and push to your registry
 
@@ -254,6 +255,9 @@ RunPod can build the worker directly from this repository:
 > The dependency installation step downloads large Python wheels and can take several minutes.
 > Open the **Build Logs** tab in the RunPod UI to verify progress while the template reports
 > "Waiting for build".
+
+A sample `test_input.json` payload is bundled at the repository root so you have a ready-made request
+body for local validation or when exercising the deployed endpoint from the RunPod dashboard.
 
 ### Create a RunPod template
 

--- a/deploy/runpod/Dockerfile
+++ b/deploy/runpod/Dockerfile
@@ -1,28 +1,44 @@
-FROM runpod/pytorch:0.7.0-cu1241-torch240-ubuntu2004
+# syntax=docker/dockerfile:1.7
 
-ENV DEBIAN_FRONTEND=noninteractive
-WORKDIR /workspace
+FROM nvidia/cuda:12.4.1-cudnn9-runtime-ubuntu22.04
 
-RUN apt-get update \
+# Remove stale third-party APT sources that may cause build failures
+RUN rm -f /etc/apt/sources.list.d/*.list
 
-    && apt-get install -y --no-install-recommends ffmpeg libsndfile1 git \
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-    && rm -rf /var/lib/apt/lists/*
-
-COPY requirements.txt ./
-COPY requirements-runpod.txt ./
-
-
-RUN python -m pip install --no-cache-dir --upgrade pip setuptools wheel \
-    && python -m pip install --no-cache-dir -r requirements-runpod.txt
-
-COPY . .
-
-RUN python -m pip install --no-cache-dir -e .
-
-
-ENV PYTHONUNBUFFERED=1 \
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONUNBUFFERED=1 \
     HF_HUB_ENABLE_HF_TRANSFER=1
 
+WORKDIR /workspace
 
-CMD ["python", "-u", "-m", "serverless.runpod_worker"]
+# Install system dependencies and Python
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        ffmpeg \
+        git \
+        libsndfile1 \
+        python3 \
+        python3-dev \
+        python3-pip \
+        python3-venv \
+        python-is-python3 \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# Upgrade pip tooling
+RUN python -m pip install --upgrade pip setuptools wheel
+
+# Install Python dependencies
+COPY requirements-runpod.txt ./requirements-runpod.txt
+RUN python -m pip install --no-cache-dir -r requirements-runpod.txt
+
+# Copy source and install the package
+COPY . .
+RUN python -m pip install --no-cache-dir -e .
+
+CMD ["python3", "-u", "-m", "serverless.runpod_worker"]

--- a/requirements-runpod.txt
+++ b/requirements-runpod.txt
@@ -1,3 +1,8 @@
+--extra-index-url https://download.pytorch.org/whl/cu124
+
+torch==2.4.0
+torchvision==0.19.0
+torchaudio==2.4.0
 descript-audio-codec
 transformers>=4.45.1,<4.47.0
 librosa
@@ -18,7 +23,7 @@ accelerate>=0.26.0
 soundfile
 tqdm
 einops
-huggingface-hub>=0.25.0
+huggingface-hub[hf_transfer]>=0.25.0
 sentencepiece
 safetensors
 runpod==1.7.13

--- a/test_input.json
+++ b/test_input.json
@@ -1,0 +1,8 @@
+{
+  "input": {
+    "script": "Hello from the Higgs Audio RunPod worker!",
+    "max_new_tokens": 128,
+    "temperature": 0.3,
+    "top_p": 0.95
+  }
+}


### PR DESCRIPTION
## Summary
- rebuild the RunPod Dockerfile on top of NVIDIA's CUDA 12.4.1 + cuDNN 9 runtime and install Python3 plus GPU PyTorch wheels
- pin torch/torchvision/torchaudio and enable hf_transfer in requirements-runpod for reliable builds
- add a sample test_input.json and update the README RunPod instructions accordingly

## Testing
- not run (infrastructure-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c92d127114833391776b3c7d84eb8c